### PR TITLE
New functions for bin/

### DIFF
--- a/.github/workflows/ci-bin.yml
+++ b/.github/workflows/ci-bin.yml
@@ -57,7 +57,7 @@ jobs:
         run: "${{ env.WEBROOT }}/${{ env.CIVI_DIR }}/bin/prepare.sh"
 
       - name: Install CiviCRM
-        run: "${{ env.WEBROOT }}/${{ env.CIVI_DIR }}/bin/install.sh ${{ env.WEBROOT }}/${{ env.CIVI_DIR }}"
+        run: "${{ env.WEBROOT }}/${{ env.CIVI_DIR }}/bin/install.sh ${{ env.WEBROOT }}/${{ env.CIVI_DIR }} --sample"
 
       - name: Get required extension (rc-base)
         uses: actions/checkout@v3

--- a/.github/workflows/ci-bin.yml
+++ b/.github/workflows/ci-bin.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install CiviCRM
         run: "${{ env.WEBROOT }}/${{ env.CIVI_DIR }}/bin/install.sh ${{ env.WEBROOT }}/${{ env.CIVI_DIR }} --sample"
 
+      - name: Reinstall CiviCRM
+        run: "${{ env.WEBROOT }}/${{ env.CIVI_DIR }}/bin/reinstall.sh ${{ env.WEBROOT }}/${{ env.CIVI_DIR }} --sample"
+
       - name: Get required extension (rc-base)
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 This repo contains a zero config CiviCRM instance on Drupal 9.
 
+**This project is intended for development/CI environments, please don't use in production!**
+
 ## Pre-requirements
 
 CiviCRM-zero is installed on a LAMP stack. So basically we need Linux, a DataBase, webserver, PHP and some tools (`composer`, `cv`).
@@ -23,14 +25,35 @@ Currently only Ubuntu is supported.
    1. Duplicate `cfg/install.cfg` and rename to `cfg/install.local`
    1. Change relevant configs in `cfg/install.local`
 1. Run `bin/prepare.sh`
-1. Run `bin/install.sh`, parameters:
-   1. Install dir (the same dir as in the 1. step)
+1. Run `bin/install.sh`, usage:
+    ```
+    install.sh INSTALL_DIR [FLAGS]...
+
+    INSTALL_DIR:    Installation dir (the same dir as in the 1. step)
+    FLAGS:          Optional flags:
+                      --sample:   load randomly generated sample data into Civi after install
+    ```
 1. (Optional) Install extensions
    1. Download extension
-   1. Run `bin/extension.sh`, parameters:
-      1. Install dir (the same dir as in the 1. step)
-      1. Extension dir
-      1. Extension key (if key is the same as the dir name, this can be omitted)
-1. (Optional) Run unit test on extensions: run `bin/tests.sh`, params:
-   1. Install dir (the same dir as in the 1. step)
-   1. Extension name
+   1. Run `bin/extension.sh`, usage:
+       ```
+       extension.sh INSTALL_DIR EXTENSION_DIR EXTENSION_KEY
+
+       INSTALL_DIR:         Installation dir (the same dir as in the 1. step)
+       EXTENSION_DIR:       Dir that contains the extension
+       EXTENSION_KEY:       Extension key (if key is the same as the dir name, this can be omitted)
+       ```
+
+## Notes
+
+- You can run `install.sh` multiple times, it will always create a fresh install.
+- To quickly reinstall CiviCRM, you can use `bin/reinstall.sh`.
+This keeps all files (`vendor/`, config files, logs, etc.) and Drupal tables in the DB, only Civi tables are purged and reinitialized.
+Parameters are the same as `install.sh`.
+- To run unit tests on extensions there's `bin/tests.sh`, usage:
+    ```
+    tests.sh INSTALL_DIR EXTENSION_DIR
+
+    INSTALL_DIR:      Installation dir (the same dir as in the 1. step)
+    EXTENSION_DIR:       Extension base dir (same as in 'extension.sh')
+    ```

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -98,6 +98,15 @@ print-finish
 
 print-finish "Drupal installed!"
 
+print-header "Install CiviCRM..."
+cv core:install \
+    --no-interaction \
+    --cwd="${install_dir}" \
+    --lang=en_GB \
+    --cms-base-url="http://${civi_domain}" \
+    --model paths.cms.root.path="${doc_root}"
+print-finish
+
 print-header "Config CiviCRM bin/setup.sh..."
 cp "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf.txt" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf"
 sed -i \
@@ -119,15 +128,6 @@ if [[ -n "${load_sample}" ]]; then
     GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -e
     print-finish
 fi
-
-print-header "Install CiviCRM..."
-cv core:install \
-    --no-interaction \
-    --cwd="${install_dir}" \
-    --lang=en_GB \
-    --cms-base-url="http://${civi_domain}" \
-    --model paths.cms.root.path="${doc_root}"
-print-finish
 
 print-header "Set permissions..."
 # Base

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -21,6 +21,7 @@ base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
 install_dir="${1?:'Install dir missing'}"
 routing="127.0.0.1 ${civi_domain}"
 doc_root="${install_dir}/web"
+config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
 
 print-header "Purge instance..."
 sudo mysql -e "DROP DATABASE IF EXISTS ${civi_db_name};"
@@ -81,6 +82,21 @@ print-header "Enable Drupal theme..."
 print-finish
 
 print-finish "Drupal installed!"
+
+print-header "Config CiviCRM bin/setup.sh..."
+cp "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf.txt" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf"
+sed -i \
+    -e "/^CIVISOURCEDIR=/ c \CIVISOURCEDIR='${install_dir}'" \
+    -e "/^DBNAME=/ c \DBNAME='${civi_db_name}'" \
+    -e "/^DBUSER=/ c \DBUSER='${civi_db_user_name}'" \
+    -e "/^DBPASS=/ c \DBPASS='${civi_db_user_pass}'" \
+    -e "/^GENCODE_CMS=/ c \GENCODE_CMS='drupal8'" \
+    "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf"
+print-finish
+
+print-header "Generate CiviCRM SQL files..."
+GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -g
+print-finish
 
 print-header "Install CiviCRM..."
 cv core:install \

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -124,8 +124,7 @@ print-finish
 
 if [[ -n "${load_sample}" ]]; then
     print-header "Load sample data..."
-    GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -s
-    GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -e
+    GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -se
     print-finish
 fi
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -105,6 +105,7 @@ cv core:install \
     --lang=en_GB \
     --cms-base-url="http://${civi_domain}" \
     --model paths.cms.root.path="${doc_root}"
+mkdir -p "${install_dir}/web/extensions"
 print-finish
 
 print-header "Config CiviCRM bin/setup.sh..."
@@ -135,7 +136,6 @@ sudo chmod -R u+w,g+r "${install_dir}"
 # Vendor (enable patching of core files)
 sudo chmod -R g+w "${install_dir}/vendor"
 # Extensions
-mkdir -p "${install_dir}/web/extensions"
 sudo chmod -R g+w "${install_dir}/web/extensions"
 # Files
 sudo chown -R www-data:www-data "${install_dir}/web/sites/default/files"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -89,13 +89,23 @@ cv core:install \
     --lang=en_GB \
     --cms-base-url="http://${civi_domain}" \
     --model paths.cms.root.path="${doc_root}"
+print-finish
+
+print-header "Set permissions..."
+# Base
 sudo chown -R "${USER}:www-data" "${install_dir}"
 sudo chmod -R u+w,g+r "${install_dir}"
+# Vendor (enable patching of core files)
+sudo chmod -R g+w "${install_dir}/vendor"
+# Extensions
+mkdir -p "${install_dir}/web/extensions"
+sudo chmod -R g+w "${install_dir}/web/extensions"
+# Files
+sudo chown -R www-data:www-data "${install_dir}/web/sites/default/files"
+sudo chmod -R g+w "${install_dir}/web/sites/default/files"
 print-finish
 
 print-header "Update civicrm.settings.php..."
-mkdir -p "${install_dir}/web/extensions"
-sudo chgrp www-data "${install_dir}/web/extensions"
 sed -i \
     -e "/\$civicrm_setting\['domain'\]\['extensionsDir'\]/ c \$civicrm_setting['domain']['extensionsDir'] = '[cms.root]/extensions';" \
     -e "/\$civicrm_setting\['domain'\]\['extensionsURL'\]/ c \$civicrm_setting['domain']['extensionsURL'] = '[cms.root]/extensions';" \
@@ -106,12 +116,6 @@ print-finish
 print-header "Clear cache..."
 sudo -u www-data "${install_dir}/vendor/bin/drush" cache:rebuild
 sudo -u www-data cv flush --cwd="${install_dir}"
-print-finish
-
-print-header "Set permissions..."
-sudo chmod g+w "${install_dir}/web/extensions"
-sudo chown -R www-data:www-data "${install_dir}/web/sites/default/files"
-sudo chmod -R g+w "${install_dir}/web/sites/default/files"
 print-finish
 
 print-header "Login to site..."

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#################################################
+## civi-zero                                   ##
+##                                             ##
+## Reinstall CiviCRM                           ##
+## Quickly reinitialize Civi DB, keep files    ##
+##                                             ##
+## Required options:                           ##
+##   $1   Install dir                          ##
+##                                             ##
+## After required options, you can give flags: ##
+##   --sample: load sample data to CiviCRM     ##
+#################################################
+
+# Strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# Include library
+base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+. "${base_dir}/library.sh"
+
+# Include configs
+. "${base_dir}/../cfg/install.cfg"
+[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+
+# Parse options
+install_dir="${1?:'Install dir missing'}"
+shift
+config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
+
+# Parse flags
+load_sample=""
+for flag in "${@}"; do
+    case "${flag}" in
+        --sample) load_sample="1" ;;
+    esac
+done
+
+if [[ -n "${load_sample}" ]]; then
+    print-header "Init DB & load sample data..."
+    GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -se
+    print-finish
+else
+    print-header "Init DB..."
+    GENCODE_CONFIG_TEMPLATE="${config_template}" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.sh" -sd
+    print-finish
+fi
+
+print-header "Clear cache..."
+sudo -u www-data "${install_dir}/vendor/bin/drush" cache:rebuild
+sudo -u www-data cv flush --cwd="${install_dir}"
+print-finish
+
+print-header "Login to site..."
+OTP=$("${install_dir}/vendor/bin/drush" uli --no-browser --uri="${civi_domain}")
+curl -LsS -o /dev/null --cookie-jar "$(mktemp)" "${OTP}"
+print-finish
+
+print-finish "CiviCRM reinstalled!"
+
+exit 0


### PR DESCRIPTION
- `install.sh`: add `--sample` flag, with this flag randomly generated sample data will be loaded into CiviCRM after install
- `reinstall.sh`: quickly reinstall only CiviCRM (keep files and Drupal)