### PR TITLE
Install: check HTTP response status code

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -165,6 +165,14 @@ if [[ "${return_code}" != "200" ]]; then
 fi
 print-finish
 
+print-header "Test Civi: GET /civicrm/contact/search..."
+return_code=$(curl -LsS -o /dev/null -w"%{http_code}" --cookie "${cookies}" "${civi_domain}/civicrm/contact/search")
+if [[ "${return_code}" != "200" ]]; then
+    print-error "Failed to GET /civicrm/contact/search"
+    exit 1
+fi
+print-finish
+
 print-finish "CiviCRM installed!"
 
 exit 0

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -156,8 +156,13 @@ sudo -u www-data cv flush --cwd="${install_dir}"
 print-finish
 
 print-header "Login to site..."
+cookies=$(mktemp)
 OTP=$("${install_dir}/vendor/bin/drush" uli --no-browser --uri="${civi_domain}")
-curl -LsS -o /dev/null --cookie-jar "$(mktemp)" "${OTP}"
+return_code=$(curl -LsS -o /dev/null -w"%{http_code}" --cookie-jar "${cookies}" "${OTP}")
+if [[ "${return_code}" != "200" ]]; then
+    print-error "Failed to login to site"
+    exit 1
+fi
 print-finish
 
 print-finish "CiviCRM installed!"


### PR DESCRIPTION
During install, we login to Drupal through a HTTP GET request to the one-time login link.

In this PR the response code is checked of this request, if not `200` then an error is raised.
Also a GET request is performed to `civicrm/contact/search` as a quick functional test for successful Civi installation.