### PR TITLE
Install to different dir than project dir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,7 @@ on:
     paths:
       - "composer.*"
 env:
-  WEBROOT: /srv/www
-  CIVI_DIR: civi-zero
+  INSTALL_DIR: /srv/www/civi-zero
 jobs:
   build:
     name: Build CiviCRM
@@ -20,17 +19,9 @@ jobs:
 
       - name: Get civi-zero
         uses: actions/checkout@v3
-        with:
-          path: ${{ env.CIVI_DIR }}
-
-      - name: Move civi-zero to web root
-        run: |
-          sudo mkdir -p ${WEBROOT}
-          sudo mv ${CIVI_DIR} ${WEBROOT}/
-          sudo chown -R ${USER} ${WEBROOT}/${CIVI_DIR}
 
       - name: Setup environment
-        run: ${WEBROOT}/${CIVI_DIR}/bin/prepare.sh
+        run: ./bin/prepare.sh
 
       - name: Install CiviCRM
-        run: ${WEBROOT}/${CIVI_DIR}/bin/install.sh ${WEBROOT}/${CIVI_DIR}
+        run: ./bin/install.sh ${INSTALL_DIR}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,7 @@ on:
       - "bin/**"
       - "cfg/**"
 env:
-  WEBROOT: /srv/www
-  CIVI_DIR: civi-zero
+  INSTALL_DIR: /srv/www/civi-zero
 jobs:
   code-style:
     name: Check code style (beautysh)
@@ -45,23 +44,15 @@ jobs:
 
       - name: Get civi-zero
         uses: actions/checkout@v3
-        with:
-          path: ${{ env.CIVI_DIR }}
-
-      - name: Move civi-zero to web root
-        run: |
-          sudo mkdir -p ${WEBROOT}
-          sudo mv ${CIVI_DIR} ${WEBROOT}/
-          sudo chown -R ${USER} ${WEBROOT}/${CIVI_DIR}
 
       - name: Setup environment
-        run: ${WEBROOT}/${CIVI_DIR}/bin/prepare.sh
+        run: ./bin/prepare.sh
 
       - name: Install CiviCRM
-        run: ${WEBROOT}/${CIVI_DIR}/bin/install.sh ${WEBROOT}/${CIVI_DIR} --sample
+        run: ./bin/install.sh ${INSTALL_DIR} --sample
 
       - name: Reinstall CiviCRM
-        run: ${WEBROOT}/${CIVI_DIR}/bin/reinstall.sh ${WEBROOT}/${CIVI_DIR} --sample
+        run: ./bin/reinstall.sh ${INSTALL_DIR} --sample
 
       - name: Get required extension (rc-base)
         uses: actions/checkout@v3
@@ -70,7 +61,7 @@ jobs:
           path: rc-base
 
       - name: Install extensions
-        run: ${WEBROOT}/${CIVI_DIR}/bin/extension.sh ${WEBROOT}/${CIVI_DIR} rc-base
+        run: ./bin/extension.sh ${INSTALL_DIR} rc-base
 
       - name: Run unit tests
-        run: ${WEBROOT}/${CIVI_DIR}/bin/tests.sh ${WEBROOT}/${CIVI_DIR} rc-base
+        run: ./bin/tests.sh ${INSTALL_DIR} rc-base

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently only Ubuntu is supported.
 
 ## Installation
 
-1. Check out repo into a dir where you want to serve it
+1. Check out repo
 1. Config installer
    1. Check `cfg/install.cfg` for defaults
    1. Duplicate `cfg/install.cfg` and rename to `cfg/install.local`
@@ -29,7 +29,7 @@ Currently only Ubuntu is supported.
     ```
     install.sh INSTALL_DIR [FLAGS]...
 
-    INSTALL_DIR:    Installation dir (the same dir as in the 1. step)
+    INSTALL_DIR:    Installation dir, where to install CiviCRM
     FLAGS:          Optional flags:
                       --sample:   load randomly generated sample data into Civi after install
     ```
@@ -39,7 +39,7 @@ Currently only Ubuntu is supported.
        ```
        extension.sh INSTALL_DIR EXTENSION_DIR EXTENSION_KEY
 
-       INSTALL_DIR:         Installation dir (the same dir as in the 1. step)
+       INSTALL_DIR:         Installation dir (the same dir where you installed in step #4)
        EXTENSION_DIR:       Dir that contains the extension
        EXTENSION_KEY:       Extension key (if key is the same as the dir name, this can be omitted)
        ```
@@ -54,6 +54,6 @@ Parameters are the same as `install.sh`.
     ```
     tests.sh INSTALL_DIR EXTENSION_DIR
 
-    INSTALL_DIR:         Installation dir (the same dir as in the 1. step)
+    INSTALL_DIR:         Installation dir (the same dir where you installed in step #4)
     EXTENSION_DIR:       Extension base dir (same as in 'extension.sh')
     ```

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -30,8 +30,8 @@ extension_target="${install_dir}/web/extensions"
 # Extension key not supplied --> it is the same as the dir
 [[ -z "${extension_key}" ]] && extension_key=$(basename "${extension_dir}")
 
-print-header "Move extension to CiviCRM (${extension_key})"
-mv "${extension_dir}" "${extension_target}/"
+print-header "Copy extension to CiviCRM (${extension_key})"
+cp -r "${extension_dir}" "${extension_target}/"
 sudo chgrp -R www-data "${extension_target}/${extension_dir}"
 print-finish
 

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -24,6 +24,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 install_dir="${1?:"Install dir missing"}"
 extension_dir="${2?:"Extension dir missing"}"
 extension_key="${3:-}"
+install_dir=$(realpath "${install_dir}")
 extension_target="${install_dir}/web/extensions"
 
 # Extension key not supplied --> it is the same as the dir

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -10,15 +10,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Include library
-base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # shellcheck source=bin/library.sh
-. "${base_dir}/library.sh"
+. "${base_dir}/bin/library.sh"
 
 # Include configs
 # shellcheck source=cfg/install.cfg
-. "${base_dir}/../cfg/install.cfg"
+. "${base_dir}/cfg/install.cfg"
 # shellcheck disable=SC1091
-[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -28,6 +28,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"
+install_dir=$(realpath "${install_dir}")
 shift
 routing="127.0.0.1 ${civi_domain}"
 doc_root="${install_dir}/web"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -57,7 +57,7 @@ fi
 mkdir -p "${doc_root}"
 sudo chgrp -R www-data "${install_dir}"
 # Vhost
-sudo cp "${install_dir}/cfg/vhost.conf" "/etc/apache2/sites-available/${civi_domain}.conf"
+sudo cp "${base_dir}/cfg/vhost.conf" "/etc/apache2/sites-available/${civi_domain}.conf"
 sudo sed -i \
     -e "s@{{ site }}@${civi_domain}@g" \
     -e "s@{{ doc_root }}@${doc_root}@g" \

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -16,15 +16,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Include library
-base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # shellcheck source=bin/library.sh
-. "${base_dir}/library.sh"
+. "${base_dir}/bin/library.sh"
 
 # Include configs
 # shellcheck source=cfg/install.cfg
-. "${base_dir}/../cfg/install.cfg"
+. "${base_dir}/cfg/install.cfg"
 # shellcheck disable=SC1091
-[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"

--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -11,15 +11,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Include library
-base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # shellcheck source=bin/library.sh
-. "${base_dir}/library.sh"
+. "${base_dir}/bin/library.sh"
 
 # Include configs
 # shellcheck source=cfg/install.cfg
-. "${base_dir}/../cfg/install.cfg"
+. "${base_dir}/cfg/install.cfg"
 # shellcheck disable=SC1091
-[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 print-header "Install Apache..."
 sudo apt-get install --yes --no-install-recommends --no-upgrade apache2 libapache2-mod-fcgid libapache2-mod-security2
@@ -47,7 +47,7 @@ sudo update-alternatives --set php "/usr/bin/php${php_version}"
 print-finish
 
 print-header "Config PHP..."
-sudo cp "${base_dir}/../cfg/civi.php.ini" "/etc/php/${php_version}/mods-available/"
+sudo cp "${base_dir}/cfg/civi.php.ini" "/etc/php/${php_version}/mods-available/"
 [[ -e "/etc/php/${php_version}/fpm/conf.d/99-civi.ini" ]] || sudo ln -s "/etc/php/${php_version}/mods-available/civi.php.ini" "/etc/php/${php_version}/fpm/conf.d/99-civi.ini"
 [[ -e "/etc/php/${php_version}/cli/conf.d/99-civi.ini" ]] || sudo ln -s "/etc/php/${php_version}/mods-available/civi.php.ini" "/etc/php/${php_version}/cli/conf.d/99-civi.ini"
 sudo sed -i \

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -17,15 +17,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Include library
-base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # shellcheck source=bin/library.sh
-. "${base_dir}/library.sh"
+. "${base_dir}/bin/library.sh"
 
 # Include configs
 # shellcheck source=cfg/install.cfg
-. "${base_dir}/../cfg/install.cfg"
+. "${base_dir}/cfg/install.cfg"
 # shellcheck disable=SC1091
-[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -29,6 +29,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"
+install_dir=$(realpath "${install_dir}")
 shift
 config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
 

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -53,12 +53,12 @@ else
 fi
 
 print-header "Clear cache..."
-sudo -u www-data "${install_dir}/vendor/bin/drush" cache:rebuild
+sudo -u www-data "${install_dir}/vendor/bin/drush" cache:rebuild --root "${install_dir}"
 sudo -u www-data cv flush --cwd="${install_dir}"
 print-finish
 
 print-header "Login to site..."
-OTP=$("${install_dir}/vendor/bin/drush" uli --no-browser --uri="${civi_domain}")
+OTP=$("${install_dir}/vendor/bin/drush" uli --root "${install_dir}" --no-browser --uri="${civi_domain}")
 tmp_file=$(mktemp)
 curl -LsS -o /dev/null --cookie-jar "${tmp_file}" "${OTP}"
 print-finish

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -23,6 +23,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # Parse options
 install_dir="${1?:"Install dir missing"}"
 extension="${2?:"Extension missing"}"
+install_dir=$(realpath "${install_dir}")
 extension_target="${install_dir}/web/extensions"
 
 print-header "Run unit tests (${extension})"

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -10,15 +10,15 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # Include library
-base_dir="$(builtin cd "$(dirname "${0}")" >/dev/null 2>&1 && pwd)"
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 # shellcheck source=bin/library.sh
-. "${base_dir}/library.sh"
+. "${base_dir}/bin/library.sh"
 
 # Include configs
 # shellcheck source=cfg/install.cfg
-. "${base_dir}/../cfg/install.cfg"
+. "${base_dir}/cfg/install.cfg"
 # shellcheck disable=SC1091
-[[ -r "${base_dir}/../cfg/install.local" ]] && . "${base_dir}/../cfg/install.local"
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
 install_dir="${1?:"Install dir missing"}"


### PR DESCRIPTION
Now Civi can be installed in a directory other than the project dir.
Only essential files are copied to install dir: `composer.*`, `.editorconfig`

This has several advantages:
- Less confusing install process
- This tool and the installed CiviCRM instance is separated
- Civi install dir is not a git repo so you can easier install extensions from git
- `.editorconfig` is copied so style can be maintained