### PR TITLE
Fix relative path for install dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,16 @@ jobs:
           repository: reflexive-communications/rc-base
           path: rc-base
 
+      - name: Get test extension (number-grouping)
+        uses: actions/checkout@v3
+        with:
+          repository: reflexive-communications/number-grouping
+          path: number-grouping
+
       - name: Install extensions
-        run: ./bin/extension.sh ${INSTALL_DIR} rc-base
+        run: |
+          ./bin/extension.sh ${INSTALL_DIR} rc-base
+          ./bin/extension.sh ${INSTALL_DIR} number-grouping
 
       - name: Run unit tests
-        run: ./bin/tests.sh ${INSTALL_DIR} rc-base
+        run: ./bin/tests.sh ${INSTALL_DIR} number-grouping

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -31,8 +31,9 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 install_dir="${1?:"Install dir missing"}"
 shift
 routing="127.0.0.1 ${civi_domain}"
-doc_root="${install_dir}/web"
-config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
+# These will get initialized later
+doc_root=
+config_template=
 
 # Parse flags
 load_sample=
@@ -51,8 +52,12 @@ print-finish
 print-header "Create install dir..."
 sudo mkdir -p "${install_dir}"
 sudo chown -R "${USER}:${USER}" "${install_dir}"
-install_dir=$(realpath "${install_dir}")
 print-finish
+
+# Use absolute paths from now on (realpath needs existing dirs)
+install_dir=$(realpath "${install_dir}")
+doc_root="${install_dir}/web"
+config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
 
 print-header "Copy essential files to install dir..."
 if [[ "${install_dir}" != "${base_dir}" ]]; then


### PR DESCRIPTION
Previously implemented feature (#28) allows `install_dir` to be a different dir than project dir.
Unfortunately there was a bug, only absolute paths could be used.

Now relative paths work too.