### PR TITLE
Civi components

### DIFF
--- a/bin/init-test-DB.sh
+++ b/bin/init-test-DB.sh
@@ -45,6 +45,7 @@ sudo -u www-data cv core:install \
     --cwd="${install_dir}" \
     --cms-base-url="https://${civi_domain}" \
     --db="mysql://${civi_db_user_name}:${civi_db_user_pass}@localhost:3306/${civi_db_test}?new_link=true" \
+    --comp="${civi_components}" \
     --keep --test
 sed -i \
     -e "/CIVICRM_UF === 'UnitTests'/ s/ && isset(\$GLOBALS\['_CV'\]\['TEST_DB_DSN'\])//" \

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -127,7 +127,8 @@ cv core:install \
     --cwd="${install_dir}" \
     --lang=en_GB \
     --cms-base-url="http://${civi_domain}" \
-    --model paths.cms.root.path="${doc_root}"
+    --model paths.cms.root.path="${doc_root}" \
+    --comp="${civi_components}"
 mkdir -p "${install_dir}/web/extensions"
 print-finish
 

--- a/cfg/install.cfg
+++ b/cfg/install.cfg
@@ -73,3 +73,5 @@ civi_site="Local CiviCRM"
 civi_user=admin
 # Civi system user pass
 civi_pass=adminpass
+# Civi enabled components
+civi_components=CiviEvent,CiviContribute,CiviMember,CiviMail,CiviReport,CiviCampaign


### PR DESCRIPTION
Add new config: `civi_components`. With this config you can set which CiviCRM components will be enabled after install (like CiviContribute, CiviMail etc.).