### PR TITLE
CI: use rc-mosaico-template instead of number-grouping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,22 +56,23 @@ jobs:
       - name: Reinstall CiviCRM
         run: ./bin/reinstall.sh ${INSTALL_DIR} --sample
 
-      - name: Get required extension (rc-base)
+      - name: Get required extension (uk.co.vedaconsulting.mosaico)
         uses: actions/checkout@v3
         with:
-          repository: reflexive-communications/rc-base
-          path: rc-base
+          repository: reflexive-communications/uk.co.vedaconsulting.mosaico
+          path: uk.co.vedaconsulting.mosaico
+          ref: build
 
-      - name: Get test extension (number-grouping)
+      - name: Get test extension (rc-mosaico-template)
         uses: actions/checkout@v3
         with:
-          repository: reflexive-communications/number-grouping
-          path: number-grouping
+          repository: reflexive-communications/rc-mosaico-template
+          path: rc-mosaico-template
 
       - name: Install extensions
         run: |
-          ./bin/extension.sh ${INSTALL_DIR} rc-base
-          ./bin/extension.sh ${INSTALL_DIR} number-grouping
+          ./bin/extension.sh ${INSTALL_DIR} uk.co.vedaconsulting.mosaico
+          ./bin/extension.sh ${INSTALL_DIR} rc-mosaico-template
 
       - name: Run unit tests
-        run: ./bin/tests.sh ${INSTALL_DIR} number-grouping
+        run: ./bin/tests.sh ${INSTALL_DIR} rc-mosaico-template


### PR DESCRIPTION
Because `number-grouping` is now a private repo.