### PR TITLE
dev-config.sh

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -37,10 +37,13 @@ jobs:
         run: ./bin/install.sh ${INSTALL_DIR} --sample
 
       - name: Clear cache
-        run: ./bin/clear-cache.sh ${INSTALL_DIR}
+        run: ./bin/clear-cache.sh
 
       - name: Init test DB
-        run: ./bin/init-test-DB.sh ${INSTALL_DIR}
+        run: ./bin/init-test-DB.sh
+
+      - name: Config CiviCRM
+        run: ./bin/dev-config.sh
 
       - name: Reinstall CiviCRM
         run: ./bin/reinstall.sh ${INSTALL_DIR} --sample

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - "bin/**"
       - "cfg/**"
-env:
-  INSTALL_DIR: /srv/www/civi-zero
 jobs:
   format:
     name: Check format
@@ -34,7 +32,7 @@ jobs:
         run: ./bin/prepare.sh
 
       - name: Install CiviCRM
-        run: ./bin/install.sh ${INSTALL_DIR} --sample
+        run: ./bin/install.sh . --sample
 
       - name: Clear cache
         run: ./bin/clear-cache.sh
@@ -46,7 +44,7 @@ jobs:
         run: ./bin/dev-config.sh
 
       - name: Reinstall CiviCRM
-        run: ./bin/reinstall.sh ${INSTALL_DIR} --sample
+        run: ./bin/reinstall.sh . --sample
 
       - name: Get model extension (rc-base)
         uses: actions/checkout@v3
@@ -55,7 +53,7 @@ jobs:
           path: rc-base
 
       - name: Install extension
-        run: ./bin/extension.sh ${INSTALL_DIR} rc-base
+        run: ./bin/extension.sh . rc-base
 
       - name: Run extension unit tests
-        run: ./bin/tests.sh ${INSTALL_DIR} rc-base
+        run: ./bin/tests.sh . rc-base

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ Currently only Ubuntu is supported.
 
 **Notes**
 
+-   You can install Civi in civi-zero project dir also, installed CiviCRM directories (`vendor/`, `web/`) are ignored by git, it won't interfere with civi-zero.
 -   You can run `install.sh` multiple times, it will always create a fresh install.
-    Only config & local files (`web/sites/default/files`) are deleted and the DB get purged, `vendor/` dir and extensions are kept intact.
+    Only config & local files (`web/sites/default/files`) are deleted and the DataBase is purged, `vendor/` dir and extension files are kept intact.
 -   To quickly reinstall CiviCRM, you can use `bin/reinstall.sh`.
     This keeps _all_ files (`vendor/`, config files, logs, etc.) and Drupal tables in the DB, only Civi tables are purged and reinitialized.
     Parameters are the same as `install.sh`.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Currently only Ubuntu is supported.
 1. Run `bin/install.sh`, usage:
 
     ```
-    install.sh INSTALL_DIR [FLAGS]...
+    install.sh [INSTALL_DIR] [FLAGS]...
 
-    INSTALL_DIR:    Installation dir, where to install CiviCRM
+    INSTALL_DIR:    Installation dir, where to install CiviCRM. Defaults to civi-zero project dir.
     FLAGS:          Optional flags:
                       --sample:   load randomly generated sample data into Civi after install
     ```
@@ -65,9 +65,9 @@ However if you plan to use it for development, there are several utility scripts
 -   `bin/init-test-DB.sh`: Initialize test DB. It's possible to use a separate DB for testing so unit tests won't mess up your database.
 
     ```
-    init-test-DB.sh INSTALL_DIR
+    init-test-DB.sh [INSTALL_DIR]
 
-    INSTALL_DIR:    Installation dir (the same dir where you installed in step #4)
+    INSTALL_DIR:    Installation dir (the same dir where you installed in step #4). Defaults to civi-zero project dir.
     ```
 
 -   `bin/tests.sh`: To run said unit tests on extensions.
@@ -82,7 +82,7 @@ However if you plan to use it for development, there are several utility scripts
 -   `bin/clear-cache.sh`: Clears Drupal & CiviCRM caches.
 
     ```
-    clear-cache.sh INSTALL_DIR
+    clear-cache.sh [INSTALL_DIR]
 
-    INSTALL_DIR:         Installation dir (the same dir where you installed in step #4)
+    INSTALL_DIR:         Installation dir (the same dir where you installed in step #4). Defaults to civi-zero project dir.
     ```

--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ However if you plan to use it for development, there are several utility scripts
 
     INSTALL_DIR:         Installation dir (the same dir where you installed in step #4). Defaults to civi-zero project dir.
     ```
+
+-   `bin/dev-config.sh`: Configure CiviCRM for development.
+
+    ```
+    dev-config.sh [INSTALL_DIR]
+
+    INSTALL_DIR:         Installation dir (the same dir where you installed in step #4). Defaults to civi-zero project dir.
+    ```

--- a/bin/clear-cache.sh
+++ b/bin/clear-cache.sh
@@ -24,7 +24,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 [[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
-install_dir="${1?:"Install dir missing"}"
+install_dir="${1:-${base_dir}}"
 install_dir=$(realpath "${install_dir}")
 
 print-header "Clear Drupal cache..."

--- a/bin/clear-cache.sh
+++ b/bin/clear-cache.sh
@@ -9,7 +9,7 @@
 ##################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/dev-config.sh
+++ b/bin/dev-config.sh
@@ -38,13 +38,12 @@ sed -i \
     "${install_dir}/web/sites/default/civicrm.settings.php"
 print-finish
 
-print-header "Config CiviCRM..."
-
-# Set API key for system user
+print-header "Set API key for system user..."
 contact_id=$(sudo -u www-data cv api4 "${cv_params[@]}" --out=list UFMatch.get +s contact_id +w "uf_id=1")
 sudo -u www-data cv api4 "${cv_params[@]}" Contact.update +v "api_key=${civi_apikey}" +w "id=${contact_id}"
+print-finish
 
-# Default From address
+print-header "Set default from address..."
 record=$(cat <<EOF
 {
     "values": {
@@ -56,13 +55,15 @@ record=$(cat <<EOF
 EOF
 )
 echo "${record}" | sudo -u www-data cv api4 "${cv_params[@]}" OptionValue.update --in=json
+print-finish
 
-# Settings
+print-header "Apply settings..."
 json=$(implode ',' "${civi_configs[@]}")
 json=$(printf '{"values":{%s}}' "${json}")
 sudo -u www-data cv api4 "${cv_params[@]}" Setting.Set "${json}"
+print-finish
 
-# CiviMail default mailbox
+print-header "Setup default mailbox..."
 localpart=$(cut -d@ -f1 <<<"${civi_mail}")
 domain=$(cut -d@ -f2 <<<"${civi_mail}")
 # Compose JSON record
@@ -90,7 +91,6 @@ EOF
 )
 record=$(tr -d '[:space:]' <<<"${record}")
 sudo -u www-data cv api4 "${cv_params[@]}" MailSettings.Save records="${record}" '{"reload":true}'
-
 print-finish
 
 print-finish "CiviCRM configured!"

--- a/bin/dev-config.sh
+++ b/bin/dev-config.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#################################################
+## civi-zero                                   ##
+##                                             ##
+## Config CiviCRM                              ##
+##                                             ##
+## Required options:                           ##
+##   $1 Install dir, where to install CiviCRM  ##
+#################################################
+
+# Strict mode
+set -euo pipefail
+IFS=$'\n\t'
+
+# Include library
+base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
+# shellcheck source=bin/library.sh
+. "${base_dir}/bin/library.sh"
+
+# Include configs
+# shellcheck source=cfg/install.cfg
+. "${base_dir}/cfg/install.cfg"
+# shellcheck disable=SC1091
+[[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
+
+# Parse options
+install_dir="${1:-${base_dir}}"
+install_dir=$(realpath "${install_dir}")
+cv_params=(--no-interaction "--cwd=${install_dir}")
+
+print-status "Update civicrm.settings.php..."
+sed -i \
+    -e "/(\!defined('CIVICRM_TEMPLATE_COMPILE_CHECK'))/,+2 s@^//@@" \
+    -e "/CIVICRM_TEMPLATE_COMPILE_CHECK/ s/FALSE/TRUE/" \
+    -e "/(\!defined('CIVICRM_LOG_HASH'))/,+2 s@^//@@" \
+    -e "/CIVICRM_LOG_HASH/ s/TRUE/FALSE/" \
+    -e "/define( 'CIVICRM_SITE_KEY'/ c define( 'CIVICRM_SITE_KEY', '${civi_sitekey}');" \
+    "${install_dir}/web/sites/default/civicrm.settings.php"
+print-finish
+
+print-header "Config CiviCRM..."
+
+# Set API key for system user
+contact_id=$(sudo -u www-data cv api4 "${cv_params[@]}" --out=list UFMatch.get +s contact_id +w "uf_id=1")
+sudo -u www-data cv api4 "${cv_params[@]}" Contact.update +v "api_key=${civi_apikey}" +w "id=${contact_id}"
+
+# Default From address
+record=$(cat <<EOF
+{
+    "values": {
+        "label": "\"${civi_user}\" <${civi_mail}>",
+        "name": "\"${civi_user}\" <${civi_mail}>"
+    },
+    "where":[["option_group_id:name","=","from_email_address"]]
+}
+EOF
+)
+echo "${record}" | sudo -u www-data cv api4 "${cv_params[@]}" OptionValue.update --in=json
+
+# Settings
+json=$(implode ',' "${civi_configs[@]}")
+json=$(printf '{"values":{%s}}' "${json}")
+sudo -u www-data cv api4 "${cv_params[@]}" Setting.Set "${json}"
+
+# CiviMail default mailbox
+localpart=$(cut -d@ -f1 <<<"${civi_mail}")
+domain=$(cut -d@ -f2 <<<"${civi_mail}")
+# Compose JSON record
+record=$(cat <<EOF
+[{
+  "id": 1,
+  "domain_id": 1,
+  "name": "bounce",
+  "is_default": true,
+  "domain": "${domain}",
+  "localpart": "${localpart}",
+  "return_path": null,
+  "protocol": "3",
+  "server": "localhost",
+  "port": null,
+  "username": "user",
+  "password": "pass",
+  "is_ssl": false,
+  "source": null,
+  "activity_status": null,
+  "is_non_case_email_skipped": false,
+  "is_contact_creation_disabled_if_no_match": false
+}]
+EOF
+)
+record=$(tr -d '[:space:]' <<<"${record}")
+sudo -u www-data cv api4 "${cv_params[@]}" MailSettings.Save records="${record}" '{"reload":true}'
+
+print-finish
+
+print-finish "CiviCRM configured!"
+
+exit 0

--- a/bin/dev-config.sh
+++ b/bin/dev-config.sh
@@ -9,7 +9,7 @@
 #################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -36,7 +36,7 @@ extension_target="${install_dir}/web/extensions"
 # Extension key not supplied --> it is the same as the dir
 [[ -z "${extension_key}" ]] && extension_key=$(basename "${extension_dir}")
 
-print-header "Copy extension to CiviCRM (${extension_key})"
+print-status "Copy extension to CiviCRM (${extension_key})"
 cp -a "${extension_dir}" "${extension_target}/"
 sudo chgrp -R www-data "${extension_target}/${extension_dir}"
 print-finish

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -36,12 +36,12 @@ extension_target="${install_dir}/web/extensions"
 # Extension key not supplied --> it is the same as the dir
 [[ -z "${extension_key}" ]] && extension_key=$(basename "${extension_dir}")
 
-print-status "Copy extension to CiviCRM (${extension_key})"
+print-status "Copy extension to CiviCRM (${extension_key})..."
 cp -a "${extension_dir}" "${extension_target}/"
 sudo chgrp -R www-data "${extension_target}/${extension_dir}"
 print-finish
 
-print-header "Enable extension (${extension_key})"
+print-header "Enable extension (${extension_key})..."
 sudo -u www-data cv ext:enable \
     --no-interaction \
     --cwd="${install_dir}" \

--- a/bin/extension.sh
+++ b/bin/extension.sh
@@ -12,7 +12,7 @@
 ####################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/init-test-DB.sh
+++ b/bin/init-test-DB.sh
@@ -27,12 +27,12 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 install_dir="${1:-${base_dir}}"
 install_dir=$(realpath "${install_dir}")
 
-print-header "Purge Civi Test DB..."
+print-status "Purge Civi Test DB..."
 sudo mysql -e "DROP DATABASE IF EXISTS ${civi_db_test}"
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS ${civi_db_test} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
 print-finish
 
-print-header "Add Civi DB user..."
+print-status "Add Civi DB user..."
 sudo mysql -e "CREATE USER IF NOT EXISTS ${civi_db_user_name}@localhost IDENTIFIED BY '${civi_db_user_pass}'"
 sudo mysql -e "GRANT ALL PRIVILEGES ON ${civi_db_test}.* TO '${civi_db_user_name}'@'localhost'"
 sudo mysql -e "GRANT SUPER ON *.* TO '${civi_db_user_name}'@'localhost'"

--- a/bin/init-test-DB.sh
+++ b/bin/init-test-DB.sh
@@ -9,7 +9,7 @@
 ##################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/init-test-DB.sh
+++ b/bin/init-test-DB.sh
@@ -24,7 +24,7 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 [[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
-install_dir="${1?:"Install dir missing"}"
+install_dir="${1:-${base_dir}}"
 install_dir=$(realpath "${install_dir}")
 
 print-header "Purge Civi Test DB..."

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -28,8 +28,8 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 [[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
-install_dir="${1?:"Install dir missing"}"
-shift
+install_dir="${1:-${base_dir}}"
+[[ "${#}" -gt 0 ]] && shift
 routing="127.0.0.1 ${civi_domain}"
 # These will get initialized later
 doc_root=

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -171,8 +171,6 @@ sed -i \
     -e "/\$civicrm_setting\['domain'\]\['extensionsDir'\]/ c \$civicrm_setting['domain']['extensionsDir'] = '[cms.root]/extensions';" \
     -e "/\$civicrm_setting\['domain'\]\['extensionsURL'\]/ c \$civicrm_setting['domain']['extensionsURL'] = '[cms.root]/extensions';" \
     -e "s@\['cms'\]\['root'\]@\['cms.root'\]@" \
-    -e "/(\!defined('CIVICRM_TEMPLATE_COMPILE_CHECK'))/,+2 s@^//@@" \
-    -e "/CIVICRM_TEMPLATE_COMPILE_CHECK/ s/FALSE/TRUE/" \
     "${install_dir}/web/sites/default/civicrm.settings.php"
 print-finish
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -13,7 +13,7 @@
 #################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -44,12 +44,12 @@ for flag in "${@}"; do
     esac
 done
 
-print-header "Purge instance..."
+print-status "Purge instance..."
 sudo mysql -e "DROP DATABASE IF EXISTS ${civi_db_name}"
 sudo rm -rf "${install_dir}/web/sites/default/civicrm.settings.php" "${install_dir}/web/sites/default/settings.php" "${install_dir}/web/sites/default/files/"
 print-finish
 
-print-header "Create install dir..."
+print-status "Create install dir..."
 sudo mkdir -p "${install_dir}"
 sudo chown -R "${USER}:${USER}" "${install_dir}"
 print-finish
@@ -59,7 +59,7 @@ install_dir=$(realpath "${install_dir}")
 doc_root="${install_dir}/web"
 config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
 
-print-header "Copy essential files to install dir..."
+print-status "Copy essential files to install dir..."
 if [[ "${install_dir}" != "${base_dir}" ]]; then
     cp "${base_dir}/composer.json" "${base_dir}/composer.lock" "${base_dir}/.editorconfig" "${install_dir}"
 fi
@@ -83,11 +83,11 @@ sudo a2ensite "${civi_domain}.conf"
 sudo systemctl reload apache2.service
 print-finish
 
-print-header "Add Civi DB..."
+print-status "Add Civi DB..."
 sudo mysql -e "CREATE DATABASE IF NOT EXISTS ${civi_db_name} DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci"
 print-finish
 
-print-header "Add Civi DB user..."
+print-status "Add Civi DB user..."
 sudo mysql -e "CREATE USER IF NOT EXISTS ${civi_db_user_name}@localhost IDENTIFIED BY '${civi_db_user_pass}'"
 sudo mysql -e "GRANT ALL PRIVILEGES ON ${civi_db_name}.* TO '${civi_db_user_name}'@'localhost'"
 sudo mysql -e "GRANT SUPER ON *.* TO '${civi_db_user_name}'@'localhost'"
@@ -132,7 +132,7 @@ cv core:install \
 mkdir -p "${install_dir}/web/extensions"
 print-finish
 
-print-header "Config CiviCRM bin/setup.sh..."
+print-status "Config CiviCRM bin/setup.sh..."
 cp "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf.txt" "${install_dir}/vendor/civicrm/civicrm-core/bin/setup.conf"
 sed -i \
     -e "/^CIVISOURCEDIR=/ c \CIVISOURCEDIR='${install_dir}'" \
@@ -153,7 +153,7 @@ if [[ -n "${load_sample}" ]]; then
     print-finish
 fi
 
-print-header "Set permissions..."
+print-status "Set permissions..."
 # Base
 sudo chown -R "${USER}:www-data" "${install_dir}"
 sudo chmod -R u+w,g+r "${install_dir}"
@@ -166,7 +166,7 @@ sudo chown -R www-data:www-data "${install_dir}/web/sites/default/files"
 sudo chmod -R g+w "${install_dir}/web/sites/default/files"
 print-finish
 
-print-header "Update civicrm.settings.php..."
+print-status "Update civicrm.settings.php..."
 sed -i \
     -e "/\$civicrm_setting\['domain'\]\['extensionsDir'\]/ c \$civicrm_setting['domain']['extensionsDir'] = '[cms.root]/extensions';" \
     -e "/\$civicrm_setting\['domain'\]\['extensionsURL'\]/ c \$civicrm_setting['domain']['extensionsURL'] = '[cms.root]/extensions';" \
@@ -186,7 +186,7 @@ print-finish
 
 "${base_dir}/bin/clear-cache.sh" "${install_dir}"
 
-print-header "Login to site..."
+print-status "Login to site..."
 cookies=$(mktemp)
 OTP=$("${install_dir}/vendor/bin/drush" uli --root "${install_dir}" --no-browser --uri="${civi_domain}")
 return_code=$(curl -LsS -o /dev/null -w"%{http_code}" --cookie-jar "${cookies}" "${OTP}")
@@ -196,7 +196,7 @@ if [[ "${return_code}" != "200" ]]; then
 fi
 print-finish
 
-print-header "Test Civi: GET /civicrm/contact/search..."
+print-status "Test Civi: GET /civicrm/contact/search..."
 return_code=$(curl -LsS -o /dev/null -w"%{http_code}" --cookie "${cookies}" "${civi_domain}/civicrm/contact/search")
 if [[ "${return_code}" != "200" ]]; then
     print-error "Failed to GET /civicrm/contact/search"

--- a/bin/library.sh
+++ b/bin/library.sh
@@ -45,6 +45,14 @@ print-header() {
     echo -e "${TXT_YELLOW}${*}${TXT_NORM}"
 }
 
+## Print status message
+##
+## @param    $*  Message
+########################
+print-status() {
+    echo -ne "${TXT_YELLOW}${*}${TXT_NORM}"
+}
+
 ## Print OK message
 ##
 ## @param    $*  Message

--- a/bin/library.sh
+++ b/bin/library.sh
@@ -70,3 +70,14 @@ print-finish() {
 print-error() {
     echo -e "${TXT_RED}${TXT_BOLD}${*}${TXT_NORM}" >&2
 }
+
+## Join arguments by char
+##
+## @param    $1  Joining character
+## @param    $*  Items to join
+##################################
+implode() {
+    local IFS="${1:?"Field separator missing"}"
+    shift
+    echo "${*}"
+}

--- a/bin/library.sh
+++ b/bin/library.sh
@@ -29,11 +29,11 @@ export BACK_BLUE="\e[44m"
 print-section() {
     local msg="${*}"
     echo
-    echo -e "${BACK_BLUE}${msg}"
+    echo -e "${BACK_BLUE}${msg}${TXT_NORM}"
     for ((i = 0 ; i < ${#msg} ; i++)); do
-        echo -n =
+        echo -ne "${BACK_BLUE}=${TXT_NORM}"
     done
-    echo -e "${TXT_NORM}"
+    echo
 }
 
 ## Print header

--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -8,7 +8,7 @@
 #######################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -51,7 +51,7 @@ sudo systemctl reload apache2.service
 sudo update-alternatives --set php "/usr/bin/php${php_version}"
 print-finish
 
-print-header "Config PHP..."
+print-status "Config PHP..."
 sudo cp "${base_dir}/cfg/civi.php.ini" "/etc/php/${php_version}/mods-available/"
 [[ -e "/etc/php/${php_version}/fpm/conf.d/99-civi.ini" ]] || sudo ln -s "/etc/php/${php_version}/mods-available/civi.php.ini" "/etc/php/${php_version}/fpm/conf.d/99-civi.ini"
 [[ -e "/etc/php/${php_version}/cli/conf.d/99-civi.ini" ]] || sudo ln -s "/etc/php/${php_version}/mods-available/civi.php.ini" "/etc/php/${php_version}/cli/conf.d/99-civi.ini"
@@ -60,7 +60,7 @@ sudo sed -i \
     "/etc/php/${php_version}/mods-available/civi.php.ini"
 print-finish
 
-print-header "Install PHP tools..."
+print-status "Install PHP tools..."
 sudo curl -LsS -o "${local_bin}/composer" "${url_composer}"
 sudo curl -LsS -o "${local_bin}/cv" "${url_cv}"
 sudo chmod +x "${local_bin}/composer"

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -13,7 +13,7 @@
 #################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -54,7 +54,7 @@ fi
 
 "${base_dir}/bin/clear-cache.sh" "${install_dir}"
 
-print-header "Login to site..."
+print-status "Login to site..."
 OTP=$("${install_dir}/vendor/bin/drush" uli --root "${install_dir}" --no-browser --uri="${civi_domain}")
 tmp_file=$(mktemp)
 curl -LsS -o /dev/null --cookie-jar "${tmp_file}" "${OTP}"

--- a/bin/reinstall.sh
+++ b/bin/reinstall.sh
@@ -28,9 +28,9 @@ base_dir="$(builtin cd "$(dirname "${0}")/.." >/dev/null 2>&1 && pwd)"
 [[ -r "${base_dir}/cfg/install.local" ]] && . "${base_dir}/cfg/install.local"
 
 # Parse options
-install_dir="${1?:"Install dir missing"}"
+install_dir="${1:-${base_dir}}"
 install_dir=$(realpath "${install_dir}")
-shift
+[[ "$#" -gt 0 ]] && shift
 config_template="${install_dir}/web/modules/contrib/civicrm/civicrm.config.php.drupal"
 
 # Parse flags

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -10,7 +10,7 @@
 ##################################################
 
 # Strict mode
-set -euo pipefail
+set -eufo pipefail
 IFS=$'\n\t'
 
 # Include library

--- a/cfg/install.cfg
+++ b/cfg/install.cfg
@@ -66,12 +66,23 @@ civi_db_user_pass=civipass
 # DB name for testing
 civi_db_test=civi_test
 # Domain
-civi_domain=civi.local.com
+civi_domain=civi.example.com
 # Site name
 civi_site="Local CiviCRM"
 # Civi system user name
 civi_user=admin
 # Civi system user pass
 civi_pass=adminpass
+# Civi system user mail
+civi_mail=admin@example.com
+# Civi system user api-key
+civi_apikey=userkey
 # Civi enabled components
 civi_components=CiviEvent,CiviContribute,CiviMember,CiviMail,CiviReport,CiviCampaign
+# Civi site-key
+civi_sitekey=sitekey12
+# Configs for Civi
+civi_configs=(
+    '"debug_enabled":1'
+    '"backtrace":1'
+)


### PR DESCRIPTION
closes #35
Also make `INSTALL_DIR` config optional for install scripts. Now it will default to civi-zero project dir as installing Civi in project root is completely normal, won't mess up with civi-zero.